### PR TITLE
Added load balancer class attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# my_jumpserver
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -29,6 +27,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Repository of the image used to deploy the jumpserver. | `string` | `"linuxserver/openssh-server"` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Tag of the image used to deploy the jumpserver. | `string` | `"9.3_p2-r0-ls133"` | no |
+| <a name="input_load_balancer_class"></a> [load\_balancer\_class](#input\_load\_balancer\_class) | The class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix. This field can only be set when the svc\_type is LoadBalancer | `string` | `null` | no |
 | <a name="input_motd_name"></a> [motd\_name](#input\_motd\_name) | Name of the place where the user joined. Defaults to 'jumpserver', so it shows: 'Welcome to jumpserver' | `string` | `"jumpserver"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource. Defaults to 'jumpserver' | `string` | `"jumpserver"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix of the resource. If not specified it won't add a prefix. | `string` | `""` | no |
@@ -41,9 +40,8 @@ No modules.
 | <a name="input_sshd_config"></a> [sshd\_config](#input\_sshd\_config) | Configuration file for SSH. If not defined it will use the default. | `string` | `""` | no |
 | <a name="input_svc_annotations"></a> [svc\_annotations](#input\_svc\_annotations) | Map of annotations for the service. | `map(any)` | `{}` | no |
 | <a name="input_svc_port"></a> [svc\_port](#input\_svc\_port) | Port where the OpenSSH will be exposed. If not defined it will use '22' as default | `number` | `22` | no |
-| <a name="input_svc_type"></a> [svc\_type](#input\_svc\_type) | Type of LoadBalancer. | `string` | `"LoadBalancer"` | no |
+| <a name="input_svc_type"></a> [svc\_type](#input\_svc\_type) | Type of the Service | `string` | `"LoadBalancer"` | no |
 
 ## Outputs
 
 No outputs.
-<!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -248,6 +248,7 @@ resource "kubernetes_service" "main" {
     }
 
     type = var.svc_type
+    load_balancer_class = var.load_balancer_class
   }
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -78,11 +78,17 @@ variable "svc_annotations" {
 variable "svc_type" {
   type        = string
   default     = "LoadBalancer"
-  description = "Type of LoadBalancer."
+  description = "Type of the Service"
 }
 
 variable "svc_port" {
   type        = number
   default     = 22
   description = "Port where the OpenSSH will be exposed. If not defined it will use '22' as default"
+}
+
+variable "load_balancer_class" {
+  type        = string
+  default     = null
+  description = "The class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix. This field can only be set when the svc_type is LoadBalancer" 
 }


### PR DESCRIPTION
This fixes the problem observed on https://github.com/montblu/terraform-kubernetes-jumpserver/issues/5
and allows to create nlb through load_balancer_class, mentioned on https://github.com/montblu/terraform-kubernetes-jumpserver/issues/6

Closes #5 